### PR TITLE
Front End Build (FEBuild.cs) - Web.config Abstraction

### DIFF
--- a/Epiphany.Core/Epiphany.Core.csproj
+++ b/Epiphany.Core/Epiphany.Core.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -42,6 +43,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FEBuild.cs" />
+    <Compile Include="FEBuildMode.cs" />
     <Compile Include="LogicHelpers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Epiphany.Core/FEBuild.cs
+++ b/Epiphany.Core/FEBuild.cs
@@ -4,7 +4,7 @@ using System.Web.Configuration;
 namespace Epiphany.Core
 {
     /// <summary>
-    /// Abstraction over the <see cref="FEBuild.APPSETTING_KEY"/> Web.config AppSetting. The
+    /// Abstraction over the <see cref="FEBuild.AppSettingKey"/> Web.config AppSetting. The
     /// setting is used to define the mode that the Front End Build has been built in. It provides
     /// the value as an Enum (defaulting to  <see cref="FEBuildMode.Development"/>) rather
     /// than a string.
@@ -31,23 +31,7 @@ namespace Epiphany.Core
         /// <summary>
         /// Web.config AppSetting key.
         /// </summary>
-        private static readonly string APPSETTING_KEY = "FEBuild.Mode";
-
-        /// <summary>
-        /// Gets the <see cref="FEBuildMode"/> from the Web.config AppSettings, defaulting to
-        /// <see cref="FEBuildMode.Development"/> if not set or unexpected value is set.
-        /// </summary>
-        private static FEBuildMode _GetMode()
-        {
-            FEBuildMode mode;
-            string value = WebConfigurationManager.AppSettings[FEBuild.APPSETTING_KEY];
-
-            if (!Enum.TryParse<FEBuildMode>(value, ignoreCase: true, result: out mode)) {
-                return FEBuildMode.Development;
-            }
-
-            return mode;
-        }
+        private static readonly string AppSettingKey = "FEBuild.Mode";
 
         /// <summary>
         /// The <see cref="FEBuildMode"/> set in the Web.config AppSettings, will default to
@@ -59,7 +43,7 @@ namespace Epiphany.Core
         ///     // ...
         /// }
         /// </example>
-        public static readonly FEBuildMode Mode = FEBuild._GetMode();
+        public static readonly FEBuildMode Mode = FEBuild.GetMode();
 
         /// <summary>
         /// Convenience to check if <see cref="Mode"/> is set to <see cref="FEBuildMode.Development"/>.
@@ -68,5 +52,21 @@ namespace Epiphany.Core
         /// <link rel="stylesheet" href="/assets/css/screen@(".min".If(FEBuild.IsDev)).css">
         /// ]]></example>
         public static readonly bool IsDev = (FEBuild.Mode == FEBuildMode.Development);
+
+        /// <summary>
+        /// Gets the <see cref="FEBuildMode"/> from the Web.config AppSettings, defaulting to
+        /// <see cref="FEBuildMode.Development"/> if not set or unexpected value is set.
+        /// </summary>
+        private static FEBuildMode GetMode()
+        {
+            FEBuildMode mode;
+            string value = WebConfigurationManager.AppSettings[FEBuild.AppSettingKey];
+
+            if (!Enum.TryParse<FEBuildMode>(value, ignoreCase: true, result: out mode)) {
+                return FEBuildMode.Development;
+            }
+
+            return mode;
+        }
     }
 }

--- a/Epiphany.Core/FEBuild.cs
+++ b/Epiphany.Core/FEBuild.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Web.Configuration;
+
+namespace Epiphany.Core
+{
+    /// <summary>
+    /// Abstraction over the <see cref="FEBuild.APPSETTING_KEY"/> Web.config AppSetting. The
+    /// setting is used to define the mode that the Front End Build has been built in. It provides
+    /// the value as an Enum (defaulting to  <see cref="FEBuildMode.Development"/>) rather
+    /// than a string.
+    /// </summary>
+    /// <example><![CDATA[
+    /// @switch (FEBuild.Mode) {
+    ///     case FEBuildMode.Production:
+    ///         <script src="/assets/js/bundle.js"></script>
+    ///         <script>
+    ///             System['import'].call(System, 'app');
+    ///         </script>
+    ///         break;
+    ///     case FEBuildMode.Development:
+    ///         <script src="/assets/js/jspm_packages/system.js"></script>
+    ///         <script src="/assets/js/config.js"></script>
+    ///         <script>
+    ///             System['import'].call(System, '/assets/js/app');
+    ///         </script>
+    ///         break;
+    /// }
+    /// ]]></example>
+    public static class FEBuild
+    {
+        /// <summary>
+        /// Web.config AppSetting key.
+        /// </summary>
+        private static readonly string APPSETTING_KEY = "FEBuild.Mode";
+
+        /// <summary>
+        /// Gets the <see cref="FEBuildMode"/> from the Web.config AppSettings, defaulting to
+        /// <see cref="FEBuildMode.Development"/> if not set or unexpected value is set.
+        /// </summary>
+        private static FEBuildMode _GetMode()
+        {
+            FEBuildMode mode;
+            string value = WebConfigurationManager.AppSettings[FEBuild.APPSETTING_KEY];
+
+            if (!Enum.TryParse<FEBuildMode>(value, ignoreCase: true, result: out mode)) {
+                return FEBuildMode.Development;
+            }
+
+            return mode;
+        }
+
+        /// <summary>
+        /// The <see cref="FEBuildMode"/> set in the Web.config AppSettings, will default to
+        /// <see cref="FEBuildMode.Development"/> if not set or unexpected value is set. The
+        /// value is set through a case insensitive parse by <see cref="Enum"/>.
+        /// </summary>
+        /// <example>
+        /// if (FEBuild.Mode == FEBuildMode.Production) {
+        ///     // ...
+        /// }
+        /// </example>
+        public static readonly FEBuildMode Mode = FEBuild._GetMode();
+
+        /// <summary>
+        /// Convenience to check if <see cref="Mode"/> is set to <see cref="FEBuildMode.Development"/>.
+        /// </summary>
+        /// <example><![CDATA[
+        /// <link rel="stylesheet" href="/assets/css/screen@(".min".If(FEBuild.IsDev)).css">
+        /// ]]></example>
+        public static readonly bool IsDev = (FEBuild.Mode == FEBuildMode.Development);
+    }
+}

--- a/Epiphany.Core/FEBuildMode.cs
+++ b/Epiphany.Core/FEBuildMode.cs
@@ -1,0 +1,18 @@
+﻿namespace Epiphany.Core
+{
+    /// <summary>
+    /// Defines the mode that the Front End has been built in.
+    /// </summary>
+    public enum FEBuildMode
+    {
+        /// <summary>
+        /// Raw assets, all seperated without minification, compression or concatination.
+        /// </summary>
+        Development,
+
+        /// <summary>
+        /// Minified, concatinated and minified assets.
+        /// </summary>
+        Production
+    }
+}


### PR DESCRIPTION
Abstraction over the `"FEBuild.Mode"` Web.config AppSetting. The setting is used to define the mode that the Front End Build has been built in. It provides the value as an Enum (defaulting to "Development") rather than a string.

It is a static class that only has two public properties:

1. **FEBuild.Mode** - Current Mode that the Front End is set to. 

   ```cshtml
   @switch (FEBuild.Mode) {
       case FEBuildMode.Production:
           <script src="/assets/js/bundle.js"></script>
           <script>
               System['import'].call(System, 'app');
           </script>
           break;
       case FEBuildMode.Development:
           <script src="/assets/js/jspm_packages/system.js"></script>
           <script src="/assets/js/config.js"></script>
           <script>
                System['import'].call(System, '/assets/js/app');
           </script>
           break;
    }
   ```

2. **FEBuild.IsDev** - Convenience to check if Mode is set to Development

   In the same spirit as the `.If` extension method, this is aiming for brevity. You could use:

   ```cshtml
   <link rel="stylesheet" href="/assets/css/screen@(".min".If(FEBuild.Mode == FEBuildMode.Development)).css">
   ```

   But I am making an assumption that checking for development will be a common use case, especially in this instance:

   ```cshtml
   <link rel="stylesheet" href="/assets/css/screen@(".min".If(FEBuild.IsDev)).css">
   ```